### PR TITLE
Add corrections to riscv example

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -255,7 +255,7 @@ jobs:
           path: c-library/risc-v-esp32-c6/target/riscv32imac-unknown-none-elf/release
       - name: Build
         run: |
-          sed -i 's/0x4086E610/0x408663A0/' "$IDF_PATH/components/esp_system/ld/esp32c6/memory.ld.in" &&
+          sed -i 's/0x4086E610/0x408629D0/' $IDF_PATH/components/esp_system/ld/esp32c6/memory.ld.in &&
           cd ./examples/c-examples/risc-v-esp32c6 && . /root/esp/esp-idf/export.sh && make && esptool.py --chip esp32c6 elf2image --flash_mode="dio" --flash_freq "40m" --flash_size "4MB" -o main.bin main.elf
 
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,7 +2,7 @@ name: Martos ci workflow
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "riscv-corrections" ]
   pull_request:
     branches: [ "main" ]
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,7 +2,7 @@ name: Martos ci workflow
 
 on:
   push:
-    branches: [ "main", "riscv-corrections" ]
+    branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
 
@@ -255,7 +255,7 @@ jobs:
           path: c-library/risc-v-esp32-c6/target/riscv32imac-unknown-none-elf/release
       - name: Build
         run: |
-          sed -i 's/0x4086E610/0x408629D0/' $IDF_PATH/components/esp_system/ld/esp32c6/memory.ld.in &&
+          sed -i 's/0x4086E610/0x408629D0/' "$IDF_PATH/components/esp_system/ld/esp32c6/memory.ld.in" &&
           cd ./examples/c-examples/risc-v-esp32c6 && . /root/esp/esp-idf/export.sh && make && esptool.py --chip esp32c6 elf2image --flash_mode="dio" --flash_freq "40m" --flash_size "4MB" -o main.bin main.elf
 
 

--- a/examples/c-examples/risc-v-esp32c6/Makefile
+++ b/examples/c-examples/risc-v-esp32c6/Makefile
@@ -12,7 +12,7 @@ CFLAGS += -fno-strict-aliasing
 CFLAGS += -fdata-sections -ffunction-sections
 CFLAGS += -Os -g
 
-LDFLAGS += -L../../../c-library/risc-v-esp32-c6/target/riscv32imac-unknown-none-elf/release/ -lrisc_v_esp32c6_static_lib
+LDFLAGS += -L../../../c-library/risc-v-esp32-c6/target/riscv32imac-unknown-none-elf/release -lrisc_v_esp32c6_static_lib
 LDFLAGS += -nostdlib -T $(LDSCRIPT) -Wl,-Map=$@.map -Wl,--cref -Wl,--gc-sections
 LDFLAGS += $(LDFLAGS_PLATFORM)
 LDFLAGS += -lgcc

--- a/examples/c-examples/risc-v-esp32c6/Makefile
+++ b/examples/c-examples/risc-v-esp32c6/Makefile
@@ -1,13 +1,9 @@
 TOOLCHAIN = riscv32-esp-elf-
 
 CFLAGS_PLATFORM = -march=rv32imac -mabi=ilp32
-ASFLAGS_PLATFORM = $(CFLAGS_PLATFORM)
 LDFLAGS_PLATFORM = $(CFLAGS_PLATFORM)
 
 CC = $(TOOLCHAIN)gcc
-LD = $(TOOLCHAIN)ld
-OC = $(TOOLCHAIN)objcopy
-OS = $(TOOLCHAIN)size
 
 LDSCRIPT       = ./ld/esp32c6.ld
 
@@ -19,9 +15,7 @@ CFLAGS += -Os -g
 LDFLAGS += -L../../../c-library/risc-v-esp32-c6/target/riscv32imac-unknown-none-elf/release/ -lrisc_v_esp32c6_static_lib
 LDFLAGS += -nostdlib -T $(LDSCRIPT) -Wl,-Map=$@.map -Wl,--cref -Wl,--gc-sections
 LDFLAGS += $(LDFLAGS_PLATFORM)
-LDFLAGS += -lm -lgcc
-ASFLAGS += -c -O0 -Wall -fmessage-length=0
-ASFLAGS += $(ASFLAGS_PLATFORM)
+LDFLAGS += -lgcc
 
 C_SRC += ./src/main.c
 

--- a/examples/c-examples/risc-v-esp32c6/Makefile
+++ b/examples/c-examples/risc-v-esp32c6/Makefile
@@ -19,7 +19,7 @@ CFLAGS += -Os -g
 LDFLAGS += -L../../../c-library/risc-v-esp32-c6/target/riscv32imac-unknown-none-elf/release/ -lrisc_v_esp32c6_static_lib
 LDFLAGS += -nostdlib -T$(LDSCRIPT) -Wl,-Map=$@.map -Wl,--cref -Wl,--gc-sections
 LDFLAGS += $(LDFLAGS_PLATFORM)
-LDFLAGS += -lm -lc -lgcc -Wl,--allow-multiple-definition
+LDFLAGS += -lm -lgcc
 ASFLAGS += -c -O0 -Wall -fmessage-length=0
 ASFLAGS += $(ASFLAGS_PLATFORM)
 

--- a/examples/c-examples/risc-v-esp32c6/Makefile
+++ b/examples/c-examples/risc-v-esp32c6/Makefile
@@ -11,20 +11,19 @@ OS = $(TOOLCHAIN)size
 
 LDSCRIPT       = ./ld/esp32c6.ld
 
-CFLAGS += $(INC) -Wall -Werror -std=gnu11 -nostdlib $(CFLAGS_PLATFORM) $(COPT)
+CFLAGS += -Wall -Werror -std=gnu11 -nostdlib $(CFLAGS_PLATFORM)
 CFLAGS += -fno-strict-aliasing
 CFLAGS += -fdata-sections -ffunction-sections
 CFLAGS += -Os -g
 
 LDFLAGS += -L../../../c-library/risc-v-esp32-c6/target/riscv32imac-unknown-none-elf/release/ -lrisc_v_esp32c6_static_lib
-LDFLAGS += -nostdlib -T$(LDSCRIPT) -Wl,-Map=$@.map -Wl,--cref -Wl,--gc-sections
+LDFLAGS += -nostdlib -T $(LDSCRIPT) -Wl,-Map=$@.map -Wl,--cref -Wl,--gc-sections
 LDFLAGS += $(LDFLAGS_PLATFORM)
 LDFLAGS += -lm -lgcc
 ASFLAGS += -c -O0 -Wall -fmessage-length=0
 ASFLAGS += $(ASFLAGS_PLATFORM)
 
-C_SRC += \
-	./src/main.c \
+C_SRC += ./src/main.c
 
 OBJS += $(C_SRC:.c=.o)
 

--- a/examples/c-examples/risc-v-esp32c6/ld/esp32c6.ld
+++ b/examples/c-examples/risc-v-esp32c6/ld/esp32c6.ld
@@ -52,52 +52,6 @@ ENTRY(call_start_cpu0);
 
 SECTIONS
 {
-
-  .iram_loader.text :
-  {
-    . = ALIGN (16);
-    _loader_text_start = ABSOLUTE(.);
-    *(.stub .gnu.warning .gnu.linkonce.literal.* .gnu.linkonce.t.*.literal .gnu.linkonce.t.*)
-    *(.iram1 .iram1.*) /* catch stray IRAM_ATTR */
-    *liblog.a:(.literal .text .literal.* .text.*)
-    /* we use either libgcc or compiler-rt, so put similar entries for them here */
-    *libgcc.a:(.literal .text .literal.* .text.*)
-    *libclang_rt.builtins.a:(.literal .text .literal.* .text.*)
-    *libbootloader_support.a:bootloader_clock_loader.*(.literal .text .literal.* .text.*)
-    *libbootloader_support.a:bootloader_common_loader.*(.literal .text .literal.* .text.*)
-    *libbootloader_support.a:bootloader_flash.*(.literal .text .literal.* .text.*)
-    *libbootloader_support.a:bootloader_random.*(.literal .text .literal.* .text.*)
-    *libbootloader_support.a:bootloader_random*.*(.literal.bootloader_random_disable .text.bootloader_random_disable)
-    *libbootloader_support.a:bootloader_random*.*(.literal.bootloader_random_enable .text.bootloader_random_enable)
-    *libbootloader_support.a:bootloader_efuse.*(.literal .text .literal.* .text.*)
-    *libbootloader_support.a:bootloader_utility.*(.literal .text .literal.* .text.*)
-    *libbootloader_support.a:bootloader_sha.*(.literal .text .literal.* .text.*)
-    *libbootloader_support.a:bootloader_console_loader.*(.literal .text .literal.* .text.*)
-    *libbootloader_support.a:bootloader_panic.*(.literal .text .literal.* .text.*)
-    *libbootloader_support.a:bootloader_soc.*(.literal .text .literal.* .text.*)
-    *libbootloader_support.a:esp_image_format.*(.literal .text .literal.* .text.*)
-    *libbootloader_support.a:flash_encrypt.*(.literal .text .literal.* .text.*)
-    *libbootloader_support.a:flash_encryption_secure_features.*(.literal .text .literal.* .text.*)
-    *libbootloader_support.a:flash_partitions.*(.literal .text .literal.* .text.*)
-    *libbootloader_support.a:secure_boot.*(.literal .text .literal.* .text.*)
-    *libbootloader_support.a:secure_boot_secure_features.*(.literal .text .literal.* .text.*)
-    *libbootloader_support.a:secure_boot_signatures_bootloader.*(.literal .text .literal.* .text.*)
-    *libmicro-ecc.a:*.*(.literal .text .literal.* .text.*)
-    *libspi_flash.a:*.*(.literal .text .literal.* .text.*)
-    *libhal.a:wdt_hal_iram.*(.literal .text .literal.* .text.*)
-    *libhal.a:mmu_hal.*(.literal .text .literal.* .text.*)
-    *libhal.a:cache_hal.*(.literal .text .literal.* .text.*)
-    *libhal.a:efuse_hal.*(.literal .text .literal.* .text.*)
-    *libesp_hw_support.a:rtc_clk.*(.literal .text .literal.* .text.*)
-    *libesp_hw_support.a:rtc_time.*(.literal .text .literal.* .text.*)
-    *libesp_hw_support.a:regi2c_ctrl.*(.literal .text .literal.* .text.*)
-    *libefuse.a:*.*(.literal .text .literal.* .text.*)
-    *(.fini.literal)
-    *(.fini)
-    *(.gnu.version)
-    _loader_text_end = ABSOLUTE(.);
-  } > iram_loader_seg
-
   .iram.text :
   {
     . = ALIGN (16);
@@ -112,7 +66,6 @@ SECTIONS
   {
     . = ALIGN (8);
     _dram_start = ABSOLUTE(.);
-    _bss_start = ABSOLUTE(.);
     *(.dynsbss)
     *(.sbss)
     *(.sbss.*)
@@ -127,14 +80,6 @@ SECTIONS
     *(.gnu.linkonce.b.*)
     *(COMMON)
     . = ALIGN (8);
-    _bss_end = ABSOLUTE(.);
-  } > dram_seg
-
-  _sidata = .;
-  .dram0.bootdesc : ALIGN(0x10)
-  {
-    _data_start = ABSOLUTE(.);
-    *(.data_bootloader_desc .data_bootloader_desc.*)               /* Should be the first.  Bootloader version info.        DO NOT PUT ANYTHING BEFORE IT! */
   } > dram_seg
 
   .dram0.data :
@@ -149,7 +94,6 @@ SECTIONS
     *(.gnu.linkonce.s.*)
     *(.gnu.linkonce.s2.*)
     *(.jcr)
-    _data_end = ABSOLUTE(.);
   } > dram_seg
 
   .dram0.rodata :
@@ -161,39 +105,6 @@ SECTIONS
     *(.rodata1)
     *(.sdata2 .sdata2.* .srodata .srodata.*)
     __XT_EXCEPTION_TABLE_ = ABSOLUTE(.);
-    *(.xt_except_table)
-    *(.gcc_except_table)
-    *(.gnu.linkonce.e.*)
-    *(.gnu.version_r)
-    *(.eh_frame_hdr)
-    *(.eh_frame)
-    . = (. + 3) & ~ 3;
-    /* C++ constructor and destructor tables, properly ordered: */
-    __init_array_start = ABSOLUTE(.);
-    KEEP (*crtbegin.*(.ctors))
-    KEEP (*(EXCLUDE_FILE (*crtend.*) .ctors))
-    KEEP (*(SORT(.ctors.*)))
-    KEEP (*(.ctors))
-    __init_array_end = ABSOLUTE(.);
-    KEEP (*crtbegin.*(.dtors))
-    KEEP (*(EXCLUDE_FILE (*crtend.*) .dtors))
-    KEEP (*(SORT(.dtors.*)))
-    KEEP (*(.dtors))
-    /*  C++ exception handlers table:  */
-    __XT_EXCEPTION_DESCS_ = ABSOLUTE(.);
-    *(.xt_except_desc)
-    *(.gnu.linkonce.h.*)
-    __XT_EXCEPTION_DESCS_END__ = ABSOLUTE(.);
-    *(.xt_except_desc_end)
-    *(.dynamic)
-    *(.gnu.version_d)
-    _rodata_end = ABSOLUTE(.);
-    /* Literals are also RO data. */
-    _lit4_start = ABSOLUTE(.);
-    *(*.lit4)
-    *(.lit4.*)
-    *(.gnu.linkonce.lit4.*)
-    _lit4_end = ABSOLUTE(.);
     . = ALIGN(4);
     _dram_end = ABSOLUTE(.);
   } > dram_seg
@@ -221,95 +132,7 @@ SECTIONS
 
   .riscv.attributes 0: { *(.riscv.attributes) }
 
-  /* DWARF 1 */
-  .debug              0 : { *(.debug) }
-  .line               0 : { *(.line) }
-  /* GNU DWARF 1 extensions */
-  .debug_srcinfo      0 : { *(.debug_srcinfo) }
-  .debug_sfnames      0 : { *(.debug_sfnames) }
-  /* DWARF 1.1 and DWARF 2 */
-  .debug_aranges      0 : { *(.debug_aranges) }
-  .debug_pubnames     0 : { *(.debug_pubnames) }
-  /* DWARF 2 */
-  .debug_info         0 : { *(.debug_info .gnu.linkonce.wi.*) }
-  .debug_abbrev       0 : { *(.debug_abbrev) }
-  .debug_line         0 : { *(.debug_line) }
-  .debug_frame        0 : { *(.debug_frame) }
-  .debug_str          0 : { *(.debug_str) }
-  .debug_loc          0 : { *(.debug_loc) }
-  .debug_macinfo      0 : { *(.debug_macinfo) }
-  .debug_pubtypes     0 : { *(.debug_pubtypes) }
-  /* DWARF 3 */
-  .debug_ranges       0 : { *(.debug_ranges) }
-  /* SGI/MIPS DWARF 2 extensions */
-  .debug_weaknames    0 : { *(.debug_weaknames) }
-  .debug_funcnames    0 : { *(.debug_funcnames) }
-  .debug_typenames    0 : { *(.debug_typenames) }
-  .debug_varnames     0 : { *(.debug_varnames) }
-  /* GNU DWARF 2 extensions */
-  .debug_gnu_pubnames 0 : { *(.debug_gnu_pubnames) }
-  .debug_gnu_pubtypes 0 : { *(.debug_gnu_pubtypes) }
-  /* DWARF 4 */
-  .debug_types        0 : { *(.debug_types) }
-  /* DWARF 5 */
-  .debug_addr         0 : { *(.debug_addr) }
-  .debug_line_str     0 : { *(.debug_line_str) }
-  .debug_loclists     0 : { *(.debug_loclists) }
-  .debug_macro        0 : { *(.debug_macro) }
-  .debug_names        0 : { *(.debug_names) }
-  .debug_rnglists     0 : { *(.debug_rnglists) }
-  .debug_str_offsets  0 : { *(.debug_str_offsets) }
-
-  .comment 0 : { *(.comment) }
-  .note.GNU-stack 0: { *(.note.GNU-stack) }
-
-  /**
-   * Discarding .rela.* sections results in the following mapping:
-   * .rela.text.* -> .text.*
-   * .rela.data.* -> .data.*
-   * And so forth...
-   */
-  /DISCARD/ : { *(.rela.*) }
-
 }
 
 INCLUDE "ld/esp32c6.rom.ld"
 PROVIDE (ets_update_cpu_frequency_rom = ets_update_cpu_frequency);
-
-INCLUDE "ld/esp32c6.rom.ld"
-PROVIDE (ets_update_cpu_frequency_rom = ets_update_cpu_frequency);
-
-/**
- *  Appendix: Memory Usage of ROM bootloader
- *
- * 0x4086ad08 ------------------> _dram0_0_start
- *            |               |
- *            |               |
- *            |               |   1. Large buffers that are only used in certain boot modes, see shared_buffers.h
- *            |               |
- *            |               |
- * 0x4087c610 ------------------> __stack_sentry
- *            |               |
- *            |               |   2. Startup pro cpu stack (freed when IDF app is running)
- *            |               |
- * 0x4087e610 ------------------> __stack (pro cpu)
- *            |               |
- *            |               |
- *            |               |   3. Shared memory only used in startup code or nonos/early boot*
- *            |               |      (can be freed when IDF runs)
- *            |               |
- *            |               |
- * 0x4087f564 ------------------> _dram0_rtos_reserved_start
- *            |               |
- *            |               |
- *            |               |   4. Shared memory used in startup code and when IDF runs
- *            |               |
- *            |               |
- * 0x4087fab0 ------------------> _dram0_rtos_reserved_end
- *            |               |
- * 0x4087fce8 ------------------> _data_start_interface
- *            |               |
- *            |               |   5. End of DRAM is the 'interface' data with constant addresses (ECO compatible)
- *            |               |
- * 0x40880000 ------------------> _data_end_interface
- */

--- a/examples/c-examples/risc-v-esp32c6/ld/esp32c6.ld
+++ b/examples/c-examples/risc-v-esp32c6/ld/esp32c6.ld
@@ -45,7 +45,7 @@ MEMORY
  * 2. Update the value in this assert.
  * 3. Update SRAM_DRAM_END in components/esp_system/ld/esp32c6/memory.ld.in to the same value.
  */
-ASSERT(bootloader_iram_loader_seg_start == 0x408629d0, "bootloader_iram_loader_seg_start inconsistent with SRAM_DRAM_END");
+ASSERT(bootloader_iram_loader_seg_start == 0x408629D0, "bootloader_iram_loader_seg_start inconsistent with SRAM_DRAM_END");
 
 /* Default entry point: */
 ENTRY(call_start_cpu0);

--- a/examples/c-examples/risc-v-esp32c6/ld/esp32c6.ld
+++ b/examples/c-examples/risc-v-esp32c6/ld/esp32c6.ld
@@ -131,7 +131,6 @@ SECTIONS
   } > iram_seg
 
   .riscv.attributes 0: { *(.riscv.attributes) }
-
 }
 
 INCLUDE "ld/esp32c6.rom.ld"

--- a/examples/c-examples/risc-v-esp32c6/ld/esp32c6.ld
+++ b/examples/c-examples/risc-v-esp32c6/ld/esp32c6.ld
@@ -53,6 +53,18 @@ ENTRY(call_start_cpu0);
 
 SECTIONS
 {
+    .iram_loader.text :
+  {
+    . = ALIGN (16);
+    _loader_text_start = ABSOLUTE(.);
+    *(.stub .gnu.warning .gnu.linkonce.literal.* .gnu.linkonce.t.*.literal .gnu.linkonce.t.*)
+    *(.iram1 .iram1.*)
+    *(.fini.literal)
+    *(.fini)
+    *(.gnu.version)
+    _loader_text_end = ABSOLUTE(.);
+  } > iram_loader_seg
+
   .rtc.text :
   {
     . = ALIGN(4);

--- a/examples/c-examples/risc-v-esp32c6/ld/esp32c6.ld
+++ b/examples/c-examples/risc-v-esp32c6/ld/esp32c6.ld
@@ -22,7 +22,7 @@
 /* These lengths can be adjusted, if necessary: */
 bootloader_usable_dram_end = 0x4087c610;
 bootloader_stack_overhead = 0x2000; /* For safety margin between bootloader data section and startup stacks */
-bootloader_dram_seg_len = 0xD270;
+bootloader_dram_seg_len = 0x10C40;
 bootloader_iram_loader_seg_len = 0x7000;
 bootloader_iram_seg_len = 0x4000;
 
@@ -36,7 +36,7 @@ MEMORY
 {
   iram_seg (RWX) :                  org = bootloader_iram_seg_start, len = bootloader_iram_seg_len
   iram_loader_seg (RWX) :           org = bootloader_iram_loader_seg_start, len = bootloader_iram_loader_seg_len
-  dram_seg (RW) :                   org = bootloader_dram_seg_start, len = bootloader_dram_seg_len + 0x38AC
+  dram_seg (RW) :                   org = bootloader_dram_seg_start, len = bootloader_dram_seg_len
 }
 
 /* The app may use RAM for static allocations up to the start of iram_loader_seg.
@@ -45,7 +45,7 @@ MEMORY
  * 2. Update the value in this assert.
  * 3. Update SRAM_DRAM_END in components/esp_system/ld/esp32c6/memory.ld.in to the same value.
  */
-ASSERT(bootloader_iram_loader_seg_start == 0x408663A0, "bootloader_iram_loader_seg_start inconsistent with SRAM_DRAM_END");
+ASSERT(bootloader_iram_loader_seg_start == 0x408629d0, "bootloader_iram_loader_seg_start inconsistent with SRAM_DRAM_END");
 
 /* Default entry point: */
 ENTRY(call_start_cpu0);

--- a/examples/c-examples/risc-v-esp32c6/ld/esp32c6.ld
+++ b/examples/c-examples/risc-v-esp32c6/ld/esp32c6.ld
@@ -37,6 +37,7 @@ MEMORY
   iram_seg (RWX) :                  org = bootloader_iram_seg_start, len = bootloader_iram_seg_len
   iram_loader_seg (RWX) :           org = bootloader_iram_loader_seg_start, len = bootloader_iram_loader_seg_len
   dram_seg (RW) :                   org = bootloader_dram_seg_start, len = bootloader_dram_seg_len
+  lp_ram_seg (RW)  :                org = 0x50000000, len = 0x4000
 }
 
 /* The app may use RAM for static allocations up to the start of iram_loader_seg.
@@ -52,6 +53,72 @@ ENTRY(call_start_cpu0);
 
 SECTIONS
 {
+  .rtc.text :
+  {
+    . = ALIGN(4);
+    _rtc_fast_start = ABSOLUTE(.);
+    _rtc_text_start = ABSOLUTE(.);
+    *(.rtc.entry.text)
+
+    *rtc_wake_stub*.*(.literal .text .literal.* .text.*)
+    *(.rtc_text_end_test)
+
+    . = ALIGN(4);
+
+    _rtc_text_end = ABSOLUTE(.);
+  } > lp_ram_seg
+
+  .rtc.force_fast :
+  {
+    . = ALIGN(4);
+    _rtc_force_fast_start = ABSOLUTE(.);
+
+    mapping[rtc_force_fast]
+
+    *(.rtc.force_fast .rtc.force_fast.*)
+    . = ALIGN(4) ;
+    _rtc_force_fast_end = ABSOLUTE(.);
+  } > lp_ram_seg
+
+  .rtc.data :
+  {
+    _rtc_data_start = ABSOLUTE(.);
+
+    mapping[rtc_data]
+
+    *rtc_wake_stub*.*(.data .rodata .data.* .rodata.* .srodata.*)
+    _rtc_data_end = ABSOLUTE(.);
+  } > lp_ram_seg
+
+  .rtc.bss (NOLOAD) :
+  {
+    _rtc_bss_start = ABSOLUTE(.);
+    *rtc_wake_stub*.*(.bss .bss.* .sbss .sbss.*)
+    *rtc_wake_stub*.*(COMMON)
+
+    mapping[rtc_bss]
+
+    _rtc_bss_end = ABSOLUTE(.);
+  } > lp_ram_seg
+
+  .rtc_noinit (NOLOAD):
+  {
+    . = ALIGN(4);
+    _rtc_noinit_start = ABSOLUTE(.);
+    *(.rtc_noinit .rtc_noinit.*)
+    . = ALIGN(4) ;
+    _rtc_noinit_end = ABSOLUTE(.);
+  } > lp_ram_seg
+
+  .rtc.force_slow :
+  {
+    . = ALIGN(4);
+    _rtc_force_slow_start = ABSOLUTE(.);
+    *(.rtc.force_slow .rtc.force_slow.*)
+    . = ALIGN(4) ;
+    _rtc_force_slow_end = ABSOLUTE(.);
+  } > lp_ram_seg
+
   .iram.text :
   {
     . = ALIGN (16);
@@ -65,6 +132,7 @@ SECTIONS
   .dram0.bss (NOLOAD) :
   {
     . = ALIGN (8);
+    _bss_start = ABSOLUTE(.);
     _dram_start = ABSOLUTE(.);
     *(.dynsbss)
     *(.sbss)
@@ -80,6 +148,7 @@ SECTIONS
     *(.gnu.linkonce.b.*)
     *(COMMON)
     . = ALIGN (8);
+    _bss_end = ABSOLUTE(.);
   } > dram_seg
 
   .dram0.data :

--- a/examples/c-examples/risc-v-esp32c6/src/main.c
+++ b/examples/c-examples/risc-v-esp32c6/src/main.c
@@ -1,6 +1,4 @@
-#include <string.h>
 #include <stdbool.h>
-extern unsigned int _bss_start, _bss_end, _sidata, _data_start, _data_end;
 
 extern void add_task(void (*setup_fn)(), void (*loop_fn)(), bool (*stop_condition_fn)());
 extern void start_task_manager();
@@ -19,7 +17,6 @@ bool stop_condition_fn() {
     if (counter == 50) {
         return true;
     }
-
     return false;
 }
 
@@ -27,20 +24,10 @@ int main( void ) {
     init_system();
     add_task(setup_fn, loop_fn, stop_condition_fn);
     start_task_manager();
-
-    // (Should never be reached)
     return 0;
 }
 
-// Application entry point / startup logic.
 void __attribute__( ( noreturn ) ) call_start_cpu0() {
-    // Clear BSS.
-    memset( &_bss_start, 0, ( &_bss_end - &_bss_start ) * sizeof( _bss_start ) );
-    // Copy initialized data.
-    memmove( &_data_start, &_sidata, ( &_data_end - &_data_start ) * sizeof( _data_start ) );
-
-    // Done, branch to main
     main();
-    // (Should never be reached)
     while( 1 ) {}
 }


### PR DESCRIPTION
- delete unnecessary clearing of bss
- change gcc flags
- delete unused sections in linker script